### PR TITLE
fix: missing step for using docker/build-push-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Build image and push
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
Ref: https://github.com/CycloneDX/cyclonedx-web-tool/issues/92
To fix: https://github.com/CycloneDX/cyclonedx-web-tool/actions/runs/2843938929 introduced by build docker image from https://github.com/CycloneDX/cyclonedx-web-tool/commit/6d619524604d441a1e8e407f30579ffbfec45296
```
/usr/bin/docker buildx build --build-arg VERSION=0.5.2 --iidfile /tmp/docker-build-push-7FIqNW/iidfile --platform linux/amd64,linux/arm64 --secret id=GIT_AUTH_TOKEN,src=/tmp/docker-build-push-7FIqNW/tmp-2033-6VgNzt1hCUW3 --tag cyclonedx/cyclonedx-web-tool:0.5.2 --tag cyclonedx/cyclonedx-web-tool:latest --metadata-file /tmp/docker-build-push-7FIqNW/metadata-file --push https://github.com/CycloneDX/cyclonedx-web-tool.git#b3d0c028c7a82e69ad63d1dc459b5af63c12fe51
error: multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")
Error: buildx failed with: error: multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")
```

Test (stripped release jobs etc) : https://github.com/zdtsw/cyclonedx-web-tool/runs/7802491915?check_suite_focus=true 